### PR TITLE
Added script for i3status-rust

### DIFF
--- a/scripts/i3status-rust.sh
+++ b/scripts/i3status-rust.sh
@@ -1,0 +1,93 @@
+#!/bin/bash
+BUDS_STATUS=`earbuds status -o json -q`
+
+REQ_STATUS=`echo $BUDS_STATUS | jq '.status' -r`
+if [ "$REQ_STATUS" != "success" ]; then
+	echo "{\"text\":\"\"}"
+    exit 1;
+fi
+
+LEFT=$(echo $BUDS_STATUS | jq -r '.payload.batt_left')
+LS=$(echo $BUDS_STATUS | jq '.payload.placement_left')
+
+RIGHT=$(echo $BUDS_STATUS | jq -r '.payload.batt_right')
+RS=$(echo $BUDS_STATUS | jq '.payload.placement_right')
+
+CASE=$(echo $BUDS_STATUS | jq '.payload.batt_case')
+
+MINIMUM=101
+
+if [ "$LEFT" -ne "0" ]
+then
+	MINIMUM=$(($MINIMUM>$LEFT ? $LEFT : $MINIMUM))
+	case $LS in
+		1)
+			LEFT="🦻 $LEFT"
+			;;
+		2)
+			LEFT="💡 $LEFT"
+			;;
+		3)
+			LEFT="⚡ $LEFT"
+			;;
+		*)
+			LEFT="﫽 $LEFT"
+			;;
+	esac
+else
+	LEFT=""
+fi
+
+if [ "$RIGHT" -ne "0" ]
+then
+	MINIMUM=$(($MINIMUM>$RIGHT ? $RIGHT : $MINIMUM))
+	case $RS in
+		1)
+			RIGHT="🦻 $RIGHT"
+			;;
+		2)
+			RIGHT="💡 $RIGHT"
+			;;
+		3)
+			RIGHT="⚡ $RIGHT"
+			;;
+		*)
+			RIGHT="﫽 $RIGHT"
+			;;
+	esac
+else
+	RIGHT=""
+fi
+
+if (($CASE <= 100))
+then
+	CASE=" 📦 $CASE"
+else
+	CASE=""
+fi
+
+
+case $MINIMUM in
+	100)
+		STATUS="Good"
+		;;
+	[5-9]*)
+		STATUS="Good"
+		;;
+	[3-4]*)
+		STATUS="Warning"
+		;;
+	[1-2]*)
+		STATUS="Critical"
+		;;
+	[0-9])
+		STATUS="Critical"
+		;;
+	*)
+		STATUS="Info"
+		;;
+esac
+
+echo "{\"icon\":\"\", \"state\":\"$STATUS\", \"text\":\"($LEFT : $RIGHT)$CASE\"}"
+
+


### PR DESCRIPTION
![image](https://user-images.githubusercontent.com/21067774/173391813-4a051612-cfa2-457b-8ce5-46dad3013142.png)

Added an example script for `i3status-rust` bar.
It is largely based on script for `waybar` with following additions:
* added case charge when available
* block is shown only if buds are connected
* only connected buds battery level is shown (if only one of the buds is connected, you'll see that)
* color of the block is changed based on battery level: green for >50%, yellow for 30-49% and red for 0-29% (the minimum among two buds is used) 

block config example:
```toml
[[block]]
block = "custom"
command = "/path/to/script.sh"
json = true
interval = 5 # seconds between updates
hide_when_empty = true # don't show this block then buds are not connected
```