### PR TITLE
Support xdg base directory spec

### DIFF
--- a/src/daemon/buds_config.rs
+++ b/src/daemon/buds_config.rs
@@ -164,7 +164,11 @@ impl Config {
 
     // Create missing folders and return the config file
     pub async fn get_config_file() -> Result<PathBuf, String> {
-        let conf_dir: PathBuf = get_home_dir().unwrap().join(".config").join("livebuds");
+        let conf_home: PathBuf = match get_xdg_config() {
+            Some(x) => x,
+            None => get_home_dir().unwrap().join(".config")
+        };
+        let conf_dir: PathBuf = conf_home.join("livebuds");
 
         if !conf_dir.exists().await {
             fs::create_dir_all(&conf_dir)
@@ -174,6 +178,13 @@ impl Config {
 
         Ok(conf_dir.join("config.toml"))
     }
+}
+
+pub fn get_xdg_config() -> Option<PathBuf> {
+    std::env::var_os("XDG_CONFIG_HOME")
+        .and_then(|xdg| if xdg.is_empty() { None } else { Some(xdg) })
+        .or(None)
+        .map(PathBuf::from)
 }
 
 pub fn get_home_dir() -> Option<PathBuf> {

--- a/src/daemon/buds_config.rs
+++ b/src/daemon/buds_config.rs
@@ -164,11 +164,10 @@ impl Config {
 
     // Create missing folders and return the config file
     pub async fn get_config_file() -> Result<PathBuf, String> {
-        let conf_home: PathBuf = match get_xdg_config() {
-            Some(x) => x,
-            None => get_home_dir().unwrap().join(".config")
-        };
-        let conf_dir: PathBuf = conf_home.join("livebuds");
+        let conf_home = get_xdg_config()
+            .or_else(|| get_home_dir().map(|i| i.join(".config")))
+            .expect("Can't determine home directory!");
+        let conf_dir = conf_home.join("livebuds");
 
         if !conf_dir.exists().await {
             fs::create_dir_all(&conf_dir)
@@ -181,17 +180,19 @@ impl Config {
 }
 
 pub fn get_xdg_config() -> Option<PathBuf> {
-    std::env::var_os("XDG_CONFIG_HOME")
-        .and_then(|xdg| if xdg.is_empty() { None } else { Some(xdg) })
-        .or(None)
-        .map(PathBuf::from)
+    try_env_var("XDG_CONFIG_HOME")
 }
 
 pub fn get_home_dir() -> Option<PathBuf> {
-    std::env::var_os("HOME")
-        .and_then(|home| if home.is_empty() { None } else { Some(home) })
-        .or(None)
-        .map(PathBuf::from)
+    try_env_var("HOME")
+}
+
+fn try_env_var(name: &str) -> Option<PathBuf>{
+    let xdg = std::env::var_os(name)?;
+    if xdg.is_empty(){
+        return None;
+    }
+    Some(PathBuf::from(xdg))
 }
 
 impl BudsConfig {


### PR DESCRIPTION
Fixes #103 

My Rust technical knowledge is not enough, but I tried to provide XDG base directory support. Detailed information about the problem can be found in #103.

It checks whether `XDG_CONFIG_HOME` exists, or it uses the default behaviour.