### PR TITLE
fix: panics in enable/disable/toggle

### DIFF
--- a/src/cmd/set_value.rs
+++ b/src/cmd/set_value.rs
@@ -31,7 +31,7 @@ pub fn set(sc: &mut SocketClient, app: &ArgMatches, toggle: bool, value: &str) {
     );
 
     // Set opt param if present
-    if app.contains_id("opt") {
+    if app.try_contains_id("opt").unwrap_or(false) {
         request.opt_param3 = app.get_one::<String>("opt").cloned();
     }
 

--- a/src/main.rs
+++ b/src/main.rs
@@ -125,7 +125,7 @@ fn run_subcommands(clap: ArgMatches) {
             &mut socket_client,
             subcommand,
             true,
-            subcommand.get_one::<String>("value").expect("required"),
+            "", // not used if toggle=true
         );
     }
 


### PR DESCRIPTION
- **fix: panic in enable/disable**
  Fixes the following panic:
  
      $ RUST_BACKTRACE=1 cargo run -- enable anc
      […]
      thread 'main' (4124055) panicked at ~/.cargo/registry/src/index.crates.io-1949cf8c6b5b557f/clap_builder-4.5.53/src/parser/matches/arg_matches.rs:524:9:
      Mismatch between definition and access of `opt`. Unknown argument or group id.  Make sure you are using the argument id and not the short or long flags
  
      stack backtrace:
         […]
         4: earbuds::cmd::set_value::set
                   at /tmp/LiveBudsCli/src/cmd/set_value.rs:34:12
         5: earbuds::run_subcommands
                   at /tmp/LiveBudsCli/src/main.rs:119:9
         6: earbuds::main::main::{{closure}}
                   at /tmp/LiveBudsCli/src/main.rs:84:5
         7: earbuds::main::{{closure}}
                   at /tmp/LiveBudsCli/src/main.rs:19:1

- **fix: panic in toggle**
  Fixes the following panic:
  
      $ RUST_BACKTRACE=1 cargo run -- toggle anc
      […]
      thread 'main' (4127873) panicked at src/main.rs:128:24:
      Mismatch between definition and access of `value`. Unknown argument or group id.  Make sure you are using the argument id and not the short or long flags
  
      stack backtrace:
         […]
         4: earbuds::run_subcommands
                   at ./src/main.rs:128:24
         5: earbuds::main::main::{{closure}}
                   at ./src/main.rs:84:5
         6: earbuds::main::{{closure}}
                   at ./src/main.rs:19:1

Related: https://github.com/JojiiOfficial/LiveBudsCli/pull/126#issuecomment-3368285278