### PR TITLE
fix: improve error messages for failed operations

### DIFF
--- a/src/cmd/config_set.rs
+++ b/src/cmd/config_set.rs
@@ -55,7 +55,7 @@ pub fn set(sc: &mut SocketClient, app: &ArgMatches) {
     } else if let Some(err_msg) = res.status_message {
         println!("Error: {}", err_msg);
     } else {
-        println!("Error!")
+        println!("Error: Operation failed");
     }
 }
 

--- a/src/cmd/set_value.rs
+++ b/src/cmd/set_value.rs
@@ -57,7 +57,7 @@ pub fn set(sc: &mut SocketClient, app: &ArgMatches, toggle: bool, value: &str) {
     } else if let Some(err_msg) = res.status_message {
         println!("Error: {}", err_msg);
     } else {
-        println!("Error!")
+        println!("Error: Operation failed");
     }
 }
 


### PR DESCRIPTION
## Summary

- Replaces bare `Error!` messages with `Error: Operation failed` in `config_set.rs` and `set_value.rs`
- Aligns with the existing `Error: {}` pattern used in adjacent code paths

The current fallback error messages print just `Error!` with no context. This changes them to `Error: Operation failed` for consistency with the rest of the error handling.

## Test plan

- [x] `rustfmt --check` -- formatting clean
- [x] Code review: no remaining bare `Error!` strings
- [x] Change is 2 lines, no logic alteration

## Hypothesis graph

https://github.com/kimjune01/sweep/blob/master/repo-hypotheses/JojiiOfficial-LiveBudsCli.md
